### PR TITLE
WIP: Default available apps for custom admin forms

### DIFF
--- a/suit/menu.py
+++ b/suit/menu.py
@@ -56,8 +56,10 @@ class MenuManager(object):
         self._available_apps = {'apps': {}, 'models': {}}
 
     def __iter__(self):
-        for each in self.get_menu_items():
-            yield each
+        menu_items = self.get_menu_items()
+        if menu_items:
+            for each in self.get_menu_items():
+                yield each
 
     def get_menu_items(self):
         if self.menu_items is None:

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -145,6 +145,11 @@ class MenuManager(object):
         return self._available_apps['models'].get(child_item._key())
 
     def build_menu_by_available_apps(self):
+        print('***************************')
+        print(self.available_apps)
+        if not self.available_apps:
+            return
+
         menu_items = []
         for native_app in self.available_apps:
             parent_item = self.make_parent_from_native_app(native_app)

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -113,6 +113,11 @@ class MenuManager(object):
         """
         Make dictionary of native apps and models for easier matching
         """
+        print('***************************')
+        print(self.available_apps)
+        if not self.available_apps:
+            return
+
         for native_app in self.available_apps:
             app_key = native_app['app_url'].split('/')[-2]
             self._available_apps['apps'][app_key] = native_app

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -56,10 +56,8 @@ class MenuManager(object):
         self._available_apps = {'apps': {}, 'models': {}}
 
     def __iter__(self):
-        menu_items = self.get_menu_items()
-        if menu_items:
-            for each in self.get_menu_items():
-                yield each
+        for each in self.get_menu_items():
+            yield each
 
     def get_menu_items(self):
         if self.menu_items is None:
@@ -115,11 +113,6 @@ class MenuManager(object):
         """
         Make dictionary of native apps and models for easier matching
         """
-        print('***************************')
-        print(self.available_apps)
-        if not self.available_apps:
-            return
-
         for native_app in self.available_apps:
             app_key = native_app['app_url'].split('/')[-2]
             self._available_apps['apps'][app_key] = native_app
@@ -147,11 +140,6 @@ class MenuManager(object):
         return self._available_apps['models'].get(child_item._key())
 
     def build_menu_by_available_apps(self):
-        print('***************************')
-        print(self.available_apps)
-        if not self.available_apps:
-            return
-
         menu_items = []
         for native_app in self.available_apps:
             parent_item = self.make_parent_from_native_app(native_app)
@@ -288,18 +276,17 @@ class MenuManager(object):
 
         request_path = str(self.request.path)
 
-        if menu_items:
-            for parent_item in menu_items:
-                if not active_child:
-                    for child_item in parent_item.children:
-                        if opts_key == child_item._key():
-                            active_child = child_item
-                            break
-                        elif not active_child_by_url and request_path == child_item.url:
-                            active_child_by_url = child_item
+        for parent_item in menu_items:
+            if not active_child:
+                for child_item in parent_item.children:
+                    if opts_key == child_item._key():
+                        active_child = child_item
+                        break
+                    elif not active_child_by_url and request_path == child_item.url:
+                        active_child_by_url = child_item
 
-                if active_child:
-                    break
+            if active_child:
+                break
 
             if not active_parent:
                 if url_name and url_name == parent_item._url_name or request_path == parent_item.url:

--- a/suit/menu.py
+++ b/suit/menu.py
@@ -286,17 +286,18 @@ class MenuManager(object):
 
         request_path = str(self.request.path)
 
-        for parent_item in menu_items:
-            if not active_child:
-                for child_item in parent_item.children:
-                    if opts_key == child_item._key():
-                        active_child = child_item
-                        break
-                    elif not active_child_by_url and request_path == child_item.url:
-                        active_child_by_url = child_item
+        if menu_items:
+            for parent_item in menu_items:
+                if not active_child:
+                    for child_item in parent_item.children:
+                        if opts_key == child_item._key():
+                            active_child = child_item
+                            break
+                        elif not active_child_by_url and request_path == child_item.url:
+                            active_child_by_url = child_item
 
-            if active_child:
-                break
+                if active_child:
+                    break
 
             if not active_parent:
                 if url_name and url_name == parent_item._url_name or request_path == parent_item.url:

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -23,13 +23,11 @@ def get_menu(context, request):
     """
     :type request: WSGIRequest
     """
-    print(type(request))
     if not isinstance(request, HttpRequest):
         return []
 
     # Django 1.9+
     available_apps = context.get('available_apps', [])
-    print('available_apps', available_apps)
     if not available_apps:
 
         # Django 1.8 on app index only
@@ -37,17 +35,14 @@ def get_menu(context, request):
 
         # Django 1.8 on rest of the pages
         if not available_apps:
-            print('SHIIIIIIIIIIIIIIIT')
             try:
                 from django.contrib import admin
                 template_response = get_admin_site(request.current_app).index(request)
-                print('template_response.context_data', template_response.context_data)
                 available_apps = template_response.context_data['app_list']
             except Exception:
                 pass
 
     if not available_apps:
-        print('OJOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO')
         logging.warn('Django Suit was unable to retrieve apps list for menu.')
 
     return MenuManager(available_apps, context, request)

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -28,13 +28,19 @@ def get_menu(context, request):
 
     # Django 1.9+
     available_apps = context.get('available_apps')
+    print('EOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO')
+    print('available_apps', available_apps)
     if not available_apps:
 
         # Django 1.8 on app index only
         available_apps = context.get('app_list')
 
+        print(context)
+        print(dict(context))
+
         # Django 1.8 on rest of the pages
         if not available_apps:
+            print('SHIIIIIIIIIIIIIIIT')
             try:
                 from django.contrib import admin
                 template_response = get_admin_site(request.current_app).index(request)

--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -23,20 +23,17 @@ def get_menu(context, request):
     """
     :type request: WSGIRequest
     """
+    print(type(request))
     if not isinstance(request, HttpRequest):
-        return None
+        return []
 
     # Django 1.9+
-    available_apps = context.get('available_apps')
-    print('EOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO')
+    available_apps = context.get('available_apps', [])
     print('available_apps', available_apps)
     if not available_apps:
 
         # Django 1.8 on app index only
-        available_apps = context.get('app_list')
-
-        print(context)
-        print(dict(context))
+        available_apps = context.get('app_list', [])
 
         # Django 1.8 on rest of the pages
         if not available_apps:
@@ -44,11 +41,13 @@ def get_menu(context, request):
             try:
                 from django.contrib import admin
                 template_response = get_admin_site(request.current_app).index(request)
+                print('template_response.context_data', template_response.context_data)
                 available_apps = template_response.context_data['app_list']
             except Exception:
                 pass
 
     if not available_apps:
+        print('OJOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO')
         logging.warn('Django Suit was unable to retrieve apps list for menu.')
 
     return MenuManager(available_apps, context, request)


### PR DESCRIPTION
When you have custom forms in the Django admin (generated by _render_ Django function) looks like **get_menu** function can't find the available apps to show the side nav. 

When this function return _None_ then a _TypeError_ is raised (`'NoneType' object is not iterable`). With this little change this exception is avoided. 

