### PR TITLE
Some templates are broken without content-wrap container

### DIFF
--- a/suit/templates/admin/base.html
+++ b/suit/templates/admin/base.html
@@ -20,7 +20,7 @@
     </h1>
 {% endblock %}
 
-{% block pretitle %}{% endblock %}
+{% block pretitle %}<div class="content-wrap">{% endblock %}
 {% block content_title %}{% endblock %}
 {% block messages %}
     <div class="messagelist">


### PR DESCRIPTION
Delete page without content-wrap container:
![delete_bad](https://user-images.githubusercontent.com/33599/115956023-cc390400-a4fa-11eb-93fc-9389c84ac989.png)

with container:
![delete_ok](https://user-images.githubusercontent.com/33599/115956037-e4108800-a4fa-11eb-99ac-606e928d46a7.png)
